### PR TITLE
Do not put annotations into the removal list that do not inherit from RECluster

### DIFF
--- a/REMarkerClusterer/REMarkerClusterer.m
+++ b/REMarkerClusterer/REMarkerClusterer.m
@@ -253,6 +253,12 @@
     [self createClusters];
     for (NSInteger j=0; j < [_mapView.annotations count]; j++) {
         RECluster *annotation = (RECluster *)[_mapView.annotations objectAtIndex:j];
+
+        // ignore annotations not managed by REMarkerCluster
+        if ([annotation isKindOfClass:[RECluster class]] == NO) {
+            continue;
+        }
+
         RECluster *fromCluster;
         BOOL found = NO;
         for (NSInteger i=0; i < [_clusters count]; i++) {


### PR DESCRIPTION
This fixes a bug where the `MKUserAnnotation` (the blue dot representing a users location on the map if `showsUserLocation` on the `MKMapView` is set to yes) would dis- and re-appear after each zoom.
