### PR TITLE
Bug while giving strange coordinates that made it crash.

### DIFF
--- a/REMarkerClusterer/REMarkerClusterer.m
+++ b/REMarkerClusterer/REMarkerClusterer.m
@@ -158,7 +158,9 @@
     
     // MKMapView BUG: this snaps to the nearest whole zoom level, which is wrong- it doesn't respect the exact region you asked for. See http://stackoverflow.com/questions/1383296/why-mkmapview-region-is-different-than-requested
     //
-    [self.mapView setRegion:region animated:YES];
+    if ((region.center.latitude >= -90) && (region.center.latitude <= 90) && (region.center.longitude >= -180) && (region.center.longitude <= 180)) {
+        [self.mapView setRegion:[self.mapView regionThatFits:region]];
+    }
 }
 
 - (double)distanceBetweenPoints:(CLLocationCoordinate2D)p1 p2:(CLLocationCoordinate2D)p2


### PR DESCRIPTION
Bug while giving strange coordinates that made it crash while setting region. Now it checks that the region is valid before setting the region.

Now the REMarkerClusterer checks that the regiojn is correct before calling to the map. In case it is not valid it just don´t do anything. In this cases we avoid the crash.
