### PR TITLE
Remove ONLY Markers Annotations

### DIFF
--- a/REMarkerClusterer/REMarkerClusterer.m
+++ b/REMarkerClusterer/REMarkerClusterer.m
@@ -85,7 +85,7 @@
 {
     [_clusters removeAllObjects];
     [_markers removeAllObjects];
-    [self.mapView removeAnnotations:self.mapView.annotations];
+    [self.mapView removeAnnotations:[self markerAnnotations]];
 }
 
 


### PR DESCRIPTION
`mapView` should remove only `markerAnnotations` and not other annotations , like MKUserLocation
