### PR TITLE
Fix subtitle bug

### DIFF
--- a/REMarkerClusterer/RECluster.m
+++ b/REMarkerClusterer/RECluster.m
@@ -140,7 +140,7 @@
     
     if (self.markers.count == 1){
         self.title = ((id<REMarker>)self.markers.lastObject).title;
-        self.subtitle = ((id<REMarker>)self.markers.lastObject).title;
+        self.subtitle = ((id<REMarker>)self.markers.lastObject).subtitle;
     } else{
         self.title = [NSString stringWithFormat:self.markerClusterer.clusterTitle, self.markers.count];
         self.subtitle = @"";


### PR DESCRIPTION
Subtitle for single-marker clusters was being incorrectly assigned.
