### PR TITLE
add method for call rrendererForOverlay

### DIFF
--- a/REMarkerClusterer/REMarkerClusterer.m
+++ b/REMarkerClusterer/REMarkerClusterer.m
@@ -576,4 +576,10 @@
     return nil;
 }
 
+-(void)mapViewDidFinishRenderingMap:(MKMapView *)mapView fullyRendered:(BOOL)fullyRendered
+{
+    if ([_delegate respondsToSelector:@selector(mapViewDidFinishRenderingMap:fullyRendered:)])
+        [_delegate mapViewDidFinishRenderingMap:mapView fullyRendered:fullyRendered];
+}
+
 @end


### PR DESCRIPTION
added method for  (MKOverlayRenderer *)mapView:(MKMapView *)mapView rendererForOverlay:(id<MKOverlay>)overlay
this very important because -(MKOverlayView *)mapView:(MKMapView *)mapView viewForOverlay:(id<MKOverlay>)overlay is deprecated  for IOS7 and later
