### PR TITLE
Allow pins to be added that are never clustered.

### DIFF
--- a/REMarkerClusterer/REMarkerClusterer.m
+++ b/REMarkerClusterer/REMarkerClusterer.m
@@ -335,13 +335,9 @@
     NSMutableArray *remainingAnnotations = [NSMutableArray arrayWithCapacity:0];
     
     for (RECluster *cluster in ((self.markerAnnotations.count > _clusters.count) ? self.markerAnnotations : _clusters)) {
-        if ([cluster isKindOfClass:[MKUserLocation class]])
-            continue;
         NSInteger numberOfMarkers = 1;
         NSMutableArray *posiblesArrays = [NSMutableArray arrayWithCapacity:0];
         for (RECluster *cluster2 in ((self.markerAnnotations.count <= _clusters.count)?self.markerAnnotations:_clusters)) {
-            if ([cluster2 isKindOfClass:[MKUserLocation class]])
-                continue;
             NSInteger markers = [cluster markersInClusterFromMarkers:cluster2.markers];
             if(markers >= numberOfMarkers){
                 [posiblesArrays addObject:cluster2];
@@ -369,8 +365,6 @@
     NSMutableDictionary *mergeators = [NSMutableDictionary dictionaryWithCapacity:0];
     
     for (RECluster *cluster in ((self.markerAnnotations.count <= _clusters.count) ? self.markerAnnotations : _clusters)) {
-        if ([cluster isKindOfClass:[MKUserLocation class]])
-            continue;
         [mergeators setObject:cluster forKey:cluster.coordinateTag];
     }
     
@@ -422,7 +416,7 @@
 {
     NSMutableArray *annotations = [NSMutableArray array];
     for (NSObject *annotation in self.mapView.annotations) {
-        if ([annotation isKindOfClass:[MKUserLocation class]])
+        if (![annotation isKindOfClass:[RECluster class]])
             continue;
         
         [annotations addObject:annotation];
@@ -472,7 +466,7 @@
         return [_delegate mapView:mapView viewForAnnotation:annotation];
     }
     
-    if ([annotation isKindOfClass:[MKUserLocation class]])
+    if (![annotation isKindOfClass:[RECluster class]])
         return nil;
     
 	static NSString *pinID = @"REMarkerClustererPin";

--- a/REMarkerClustererExample/REMarkerClustererExample/DemoViewController.m
+++ b/REMarkerClustererExample/REMarkerClustererExample/DemoViewController.m
@@ -94,6 +94,9 @@
 
 - (void)mapView:(MKMapView *)mapView annotationView:(MKAnnotationView *)view calloutAccessoryControlTapped:(UIControl *)control
 {
+    if (![view.annotation isKindOfClass:[RECluster class]])
+        return;
+
     RECluster *cluster = view.annotation;
     NSString *message;
     
@@ -112,9 +115,9 @@
    - (MKAnnotationView *)mapView:(MKMapView *)mapView viewForAnnotation:(id<MKAnnotation>)annotation
    to have custom pin views as goes below:
  */
-- (MKAnnotationView *)mapView:(MKMapView *)mapView viewForAnnotation:(RECluster *)annotation
+- (MKAnnotationView *)mapView:(MKMapView *)mapView viewForAnnotation:(id<MKAnnotation>)annotation
 {
-    if ([annotation isKindOfClass:[MKUserLocation class]])
+    if (![annotation isKindOfClass:[RECluster class]])
         return nil;
     
     static NSString *pinID;
@@ -122,10 +125,11 @@
     static NSString *clusterPinID = @"REClusterPin";
     static NSString *markerPinID = @"REMarkerPin";
     
+    NSArray *markers = ((RECluster *)annotation).markers;
     if (self.segmentedControl.selectedSegmentIndex == 0) {
         pinID = defaultPinID;
     } else {
-        pinID = annotation.markers.count == 1 ? markerPinID : clusterPinID;
+        pinID = markers.count == 1 ? markerPinID : clusterPinID;
     }
     
 	MKPinAnnotationView *pinView = (MKPinAnnotationView *)[self.mapView dequeueReusableAnnotationViewWithIdentifier:pinID];
@@ -141,7 +145,7 @@
         pinView.canShowCallout = YES;
         
         if (self.segmentedControl.selectedSegmentIndex == 1) {
-            pinView.image = [UIImage imageNamed:annotation.markers.count == 1 ? @"Pin_Red" : @"Pin_Purple"];
+            pinView.image = [UIImage imageNamed:markers.count == 1 ? @"Pin_Red" : @"Pin_Purple"];
         }
     }
     


### PR DESCRIPTION
Ignore all MKAnnotation objects that are not RECluster objects.