### PR TITLE
Clear MKMapView delegate in dealloc.

### DIFF
--- a/REMarkerClusterer/REMarkerClusterer.m
+++ b/REMarkerClusterer/REMarkerClusterer.m
@@ -70,6 +70,13 @@
     return self;
 }
 
+- (void)dealloc
+{
+    // Break the MKMapView delegate connection to avoid potential use after
+    // free bugs.
+    _mapView.delegate = nil;
+}
+
 - (void)setMapView:(MKMapView *)mapView
 {
     _mapView = mapView;


### PR DESCRIPTION
This prevents potential "use after free" bugs that I have seen
when working with MKMapView.