### PR TITLE
Add pre/post clusterize hooks.

### DIFF
--- a/REMarkerClusterer/REMarkerClusterer.h
+++ b/REMarkerClusterer/REMarkerClusterer.h
@@ -36,6 +36,8 @@
 @optional
 
 - (void)markerClusterer:(REMarkerClusterer *)markerCluster withMapView:(MKMapView *)mapView updateViewOfAnnotation:(id<MKAnnotation>)annotation withView:(MKAnnotationView *)annotationView;
+- (void)willClusterize:(REMarkerClusterer *)markerClusterer;
+- (void)didClusterize:(REMarkerClusterer *)markerClusterer;
 
 @end
 


### PR DESCRIPTION
Added optional willClusterize: and didClusterize: methods to the
REMarkerClusterDelegate protocol to allow applications to do things like
save and restore the selected annotation when re-clustering occurs.

Note: If the delegate provides a willClusterize: method, annotations are
not automatically deselected within the mapView:regionDidChangeAnimated:
method; the delegate is responsible for ensuring that the correct annotation
is selected.